### PR TITLE
Bump spring-boot-starter-parent from 2.0.4.RELEASE to 2.0.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.4.RELEASE</version>
+		<version>2.0.5.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Bumps spring-boot-starter-parent from 2.0.4.RELEASE to 2.0.5.RELEASE.